### PR TITLE
Sidekiq monitoring apps for WH, publisher signon

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem 'rack', '~> 1.5.2'
+gem 'sidekiq', '~> 3.2.1'
+gem 'sinatra', '1.3.2'
+gem 'foreman', '0.63.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,41 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    celluloid (0.15.2)
+      timers (~> 1.1.0)
+    connection_pool (2.0.0)
+    dotenv (0.11.1)
+      dotenv-deployment (~> 0.0.2)
+    dotenv-deployment (0.0.2)
+    foreman (0.63.0)
+      dotenv (>= 0.7)
+      thor (>= 0.13.6)
+    json (1.8.1)
+    rack (1.5.2)
+    rack-protection (1.5.3)
+      rack
+    redis (3.1.0)
+    redis-namespace (1.5.0)
+      redis (~> 3.0, >= 3.0.4)
+    sidekiq (3.2.1)
+      celluloid (>= 0.15.2)
+      connection_pool (>= 2.0.0)
+      json
+      redis (>= 3.0.6)
+      redis-namespace (>= 1.3.1)
+    sinatra (1.3.2)
+      rack (~> 1.3, >= 1.3.6)
+      rack-protection (~> 1.2)
+      tilt (~> 1.3, >= 1.3.3)
+    thor (0.19.1)
+    tilt (1.4.1)
+    timers (1.1.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  foreman (= 0.63.0)
+  rack (~> 1.5.2)
+  sidekiq (~> 3.2.1)
+  sinatra (= 1.3.2)

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,3 @@
+publisher: sh -c 'cd publisher && bundle exec rackup -p 3079'
+signon: sh -c 'cd signon && bundle exec rackup -p 3080'
+whitehall: sh -c 'cd whitehall && bundle exec rackup -p 3081'

--- a/publisher/config.ru
+++ b/publisher/config.ru
@@ -1,0 +1,10 @@
+require 'sidekiq'
+
+Sidekiq.configure_client do |config|
+  config.redis = YAML.load_file(File.join(__dir__, 'redis.yml')).symbolize_keys
+end
+
+require 'sidekiq/web'
+map '/publisher' do
+  run Sidekiq::Web
+end

--- a/publisher/redis.yml
+++ b/publisher/redis.yml
@@ -1,0 +1,4 @@
+# this file gets overriden on deploy
+host: 127.0.0.1
+port: 6379
+namespace: publisher 

--- a/signon/config.ru
+++ b/signon/config.ru
@@ -1,0 +1,10 @@
+require 'sidekiq'
+
+Sidekiq.configure_client do |config|
+  config.redis = YAML.load_file(File.join(__dir__, 'redis.yml')).symbolize_keys
+end
+
+require 'sidekiq/web'
+map '/signon' do
+  run Sidekiq::Web
+end

--- a/signon/redis.yml
+++ b/signon/redis.yml
@@ -1,0 +1,4 @@
+# this file gets overriden on deploy
+host: 127.0.0.1
+port: 6379
+namespace: signon

--- a/whitehall/config.ru
+++ b/whitehall/config.ru
@@ -1,0 +1,10 @@
+require 'sidekiq'
+
+Sidekiq.configure_client do |config|
+  config.redis = YAML.load_file(File.join(__dir__, 'redis.yml')).symbolize_keys
+end
+
+require 'sidekiq/web'
+map '/whitehall' do
+  run Sidekiq::Web
+end

--- a/whitehall/redis.yml
+++ b/whitehall/redis.yml
@@ -1,0 +1,4 @@
+# this file gets overriden on deploy
+host: 127.0.0.1
+port: 6379
+namespace: whitehall


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/5040

This PR contains sidekiq monitoring web applications configured as [standalone](https://github.com/mperham/sidekiq/wiki/Monitoring#standalone) apps.

Each directory contains a rack configuration and a redis configuration. `rackup` will read the `config.ru` and bring up the sidekiq monitoring web interface. Sidekiq uses redis to persist queue information, hence the `redis.yml` will provide it information about the redis instance to use.

These apps will run as standalone web apps on our production boxes and will be restricted from public access.
