### PR TITLE
Explicitly set LC_ALL to set the locale

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,5 @@
-publisher: cd publisher && exec bundle exec rackup -p 3079
-signon: cd signon && exec bundle exec rackup -p 3080
-whitehall: cd whitehall && exec bundle exec rackup -p 3081
-transition: cd transition && exec bundle exec rackup -p 3086
-email-alert-api: cd email-alert-api && exec bundle exec rackup -p 3089
+publisher: cd publisher && LC_ALL=en_GB.UTF-8 exec bundle exec rackup -p 3079
+signon: cd signon && LC_ALL=en_GB.UTF-8 exec bundle exec rackup -p 3080
+whitehall: cd whitehall && LC_ALL=en_GB.UTF-8 exec bundle exec rackup -p 3081
+transition: cd transition && LC_ALL=en_GB.UTF-8 exec bundle exec rackup -p 3086
+email-alert-api: cd email-alert-api && LC_ALL=en_GB.UTF-8 exec bundle exec rackup -p 3089


### PR DESCRIPTION
Without setting the locale explicitly, sidekiq-monitoring failed (with a
500 error) when trying to view jobs if the job containined any non ASCII
characters.  This seems to be because ruby's JSON library assumes that
raw JSON is US-ASCII in the absence of a locale setting: specifically, I
saw:

   Encoding::InvalidByteSequenceError - xE2 on US-ASCII

coming from a call to 'load_json'.

The sidekiq-monitoring processes failed to pick up the LC_ALL setting
from /etc/environment (I verified this by checking their environment
setting in /proc/PID/environ).

Setting the LC_ALL setting this way is a bit nasty, but does at least
make the thing work.
