### PR TITLE
Bump Rack for security fix.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'rack', '~> 1.5.2'
+gem 'rack', '~> 1.5.4'
 gem 'sidekiq', '~> 3.2.1'
 gem 'sinatra', '1.3.2'
 gem 'foreman', '0.75.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GEM
       dotenv (~> 0.11.1)
       thor (~> 0.19.1)
     json (1.8.1)
-    rack (1.5.2)
+    rack (1.5.4)
     rack-protection (1.5.3)
       rack
     redis (3.1.0)
@@ -36,6 +36,6 @@ PLATFORMS
 
 DEPENDENCIES
   foreman (= 0.75.0)
-  rack (~> 1.5.2)
+  rack (~> 1.5.4)
   sidekiq (~> 3.2.1)
   sinatra (= 1.3.2)


### PR DESCRIPTION
Upgrade Rack to 1.5.4 to pick up fix for CVE-2015-3225.