### PR TITLE
Add configuration for publishing-api.

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -4,3 +4,4 @@ whitehall: cd whitehall && LC_ALL=en_GB.UTF-8 exec bundle exec rackup -p 3081
 transition: cd transition && LC_ALL=en_GB.UTF-8 exec bundle exec rackup -p 3086
 email-alert-api: cd email-alert-api && LC_ALL=en_GB.UTF-8 exec bundle exec rackup -p 3089
 rummager: cd rummager && LC_ALL=en_GB.UTF-8 exec bundle exec rackup -p 3091
+publishing-api: cd publishing-api && LC_ALL=en_GB.UTF-8 exec govuk_setenv publishing-api bundle exec rackup -p 3114

--- a/public/index.html
+++ b/public/index.html
@@ -29,6 +29,7 @@
       <li><a href="/transition">Transition</a></li>
       <li><a href="/email-alert-api">Email Alert API</a></li>
       <li><a href="/rummager">Rummager</a></li>
+      <li><a href="/publishing-api">Publishing API</a></li>
     </ul>
   </body>
 </html>

--- a/publishing-api/config.ru
+++ b/publishing-api/config.ru
@@ -1,0 +1,14 @@
+require 'sidekiq'
+
+Sidekiq.configure_client do |config|
+  config.redis = {
+    host: ENV["REDIS_HOST"] || "127.0.0.1",
+    port: ENV["REDIS_PORT"] || 6379,
+    namespace: "publishing_api",
+  }
+end
+
+require 'sidekiq/web'
+map '/publishing-api' do
+  run Sidekiq::Web
+end


### PR DESCRIPTION
This is the first to use environment variables, rather than a redis.yml which
is overwritten on deploy, to specify the Redis config. So the rack app needs to
be run under govuk_setenv so it can pick up the vars already created for the
actual publishing-api app by Puppet.