### PR TITLE
Add imminence

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -6,3 +6,4 @@ email-alert-api: cd email-alert-api && LC_ALL=en_GB.UTF-8 exec bundle exec racku
 rummager: cd rummager && LC_ALL=en_GB.UTF-8 exec bundle exec rackup -p 3091
 publishing-api: cd publishing-api && LC_ALL=en_GB.UTF-8 exec govuk_setenv publishing-api bundle exec rackup -p 3114
 email-campaign-api: cd email-campaign-api && LC_ALL=en_GB.UTF-8 exec bundle exec rackup -p 3117
+imminence: cd imminence && LC_ALL=en_GB.UTF-8 exec bundle exec rackup -p 3120

--- a/imminence/config.ru
+++ b/imminence/config.ru
@@ -1,0 +1,10 @@
+require 'sidekiq'
+
+Sidekiq.configure_client do |config|
+  config.redis = YAML.load_file(File.join(__dir__, 'redis.yml')).symbolize_keys
+end
+
+require 'sidekiq/web'
+map '/imminence' do
+  run Sidekiq::Web
+end

--- a/imminence/redis.yml
+++ b/imminence/redis.yml
@@ -1,0 +1,4 @@
+# this file gets overriden on deploy
+host: 127.0.0.1
+port: 6379
+namespace: imminence-development

--- a/public/index.html
+++ b/public/index.html
@@ -31,6 +31,7 @@
       <li><a href="/rummager">Rummager</a></li>
       <li><a href="/publishing-api">Publishing API</a></li>
       <li><a href="/email-campaign-api">Email Campaign API</a></li>
+      <li><a href="/imminence">Imminence</a></li>
     </ul>
   </body>
 </html>


### PR DESCRIPTION
Unlike other apps imminence uses "classic" rails environment namespacing for
redis so the defualt redis namespace is "imminence_development", not just
"imminence".

See: 

* https://github.gds/gds/development/pull/299
* https://github.com/alphagov/govuk-puppet/pull/4172
* https://github.gds/gds/alphagov-deployment/pull/1152

For the other moving parts and https://trello.com/c/A5bWfOlG/317-add-imminence-to-sidekiq-monitoring-app-3 for the full context.