### PR TITLE
Use env vars for Whitehall

### DIFF
--- a/whitehall/config.ru
+++ b/whitehall/config.ru
@@ -1,7 +1,11 @@
 require 'sidekiq'
 
 Sidekiq.configure_client do |config|
-  config.redis = YAML.load_file(File.join(__dir__, 'redis.yml')).symbolize_keys
+  config.redis = {
+    host: ENV["REDIS_HOST"] || "127.0.0.1",
+    port: ENV["REDIS_PORT"] || 6379,
+    namespace: "whitehall",
+  }
 end
 
 require 'sidekiq/web'

--- a/whitehall/redis.yml
+++ b/whitehall/redis.yml
@@ -1,4 +1,0 @@
-# this file gets overriden on deploy
-host: 127.0.0.1
-port: 6379
-namespace: whitehall


### PR DESCRIPTION
Whitehall Sidekiq is now configured using env vars which has caused monitoring to fail. This commit switches monitoring to use the env vars to ensure the correct host is being monitored.