### PR TITLE
Add monitoring to Content Performance Manager

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,4 @@
+content-performance-manager: GOVUK_APP_NAME=content-performance-manager bundle exec rackup -p 3207
 content-tagger: GOVUK_APP_NAME=content-tagger bundle exec rackup -p 3125
 dfid-transition: GOVUK_APP_NAME=dfid-transition bundle exec rackup -p 3124
 email-alert-api: GOVUK_APP_NAME=email-alert-api bundle exec rackup -p 3089


### PR DESCRIPTION
Content Performance Manager is using Sidekiq to run jobs in the
background; as a result, we would like to monitor it within GOV.UK
infrastructure.

See: 
- https://github.gds/gds/development/pull/385,
- https://github.gds/gds/development/pull/384