### PR TITLE
Add asset manager

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,4 @@
+asset-manager: GOVUK_APP_NAME=asset-manager bundle exec rackup -p 3038
 content-performance-manager: GOVUK_APP_NAME=content-performance-manager bundle exec rackup -p 3207
 content-tagger: GOVUK_APP_NAME=content-tagger bundle exec rackup -p 3125
 dfid-transition: GOVUK_APP_NAME=dfid-transition bundle exec rackup -p 3124

--- a/public/index.html
+++ b/public/index.html
@@ -23,6 +23,7 @@
     <h1>Sidekiq monitoring apps</h1>
 
     <ul>
+      <li><a href="/asset-manager">Asset Manager</a></li>
       <li><a href="/content-performance-manager">Content Performance Manager</a></li>
       <li><a href="/content-tagger">Content Tagger</a></li>
       <li><a href="/dfid-transition">DFID Transition</a></li>


### PR DESCRIPTION
This assumes that port 3038 has been assigned to asset manager and
that `/asset-manager` has been added to the `vhost` config in
`govuk-puppet` as per the instructions[1]. [This PR](https://github.com/alphagov/govuk-puppet/pull/6501) against `alphagov/govuk-puppet` does that. 

[1] https://docs.publishing.service.gov.uk/manual/setting-up-new-sidekiq-monitoring-app.html#adding-configuration-for-your-application-in-sidekiq-monitoring-repository