### PR TITLE
Add Content Audit Tool

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,5 @@
 asset-manager: GOVUK_APP_NAME=asset-manager bundle exec rackup -p 3038
+content-audit-tool: GOVUK_APP_NAME=content-audit-tool bundle exec rackup -p 3212
 content-performance-manager: GOVUK_APP_NAME=content-performance-manager bundle exec rackup -p 3207
 content-tagger: GOVUK_APP_NAME=content-tagger bundle exec rackup -p 3125
 dfid-transition: GOVUK_APP_NAME=dfid-transition bundle exec rackup -p 3124

--- a/public/index.html
+++ b/public/index.html
@@ -24,6 +24,7 @@
 
     <ul>
       <li><a href="/asset-manager">Asset Manager</a></li>
+      <li><a href="/content-audit-tool">Content Audit Tool</a></li>
       <li><a href="/content-performance-manager">Content Performance Manager</a></li>
       <li><a href="/content-tagger">Content Tagger</a></li>
       <li><a href="/dfid-transition">DFID Transition</a></li>


### PR DESCRIPTION
This assumes that port 3212 has been assigned to Content Audit Tool
and that `/content-audit-tool` has been added to the vhost config
in govuk-puppet as per [1]. 

Related PRs in govuk-puppet for the port [2] and vhost config [3].

[1] https://docs.publishing.service.gov.uk/manual/setting-up-new-sidekiq-monitoring-app.html#adding-configuration-for-your-application-in-sidekiq-monitoring-repository
[2] https://github.com/alphagov/govuk-puppet/pull/7141
[3] https://github.com/alphagov/govuk-puppet/pull/7155