### PR TITLE
Add Content Publisher

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -2,6 +2,7 @@ asset-manager: GOVUK_APP_NAME=asset-manager bundle exec rackup -p 3038
 collections-publisher: GOVUK_APP_NAME=collections-publisher bundle exec rackup -p 3216
 content-audit-tool: GOVUK_APP_NAME=content-audit-tool bundle exec rackup -p 3217
 content-performance-manager: GOVUK_APP_NAME=content-performance-manager bundle exec rackup -p 3207
+content-publisher: GOVUK_APP_NAME=content-publisher bundle exec rackup -p 3236
 content-tagger: GOVUK_APP_NAME=content-tagger bundle exec rackup -p 3125
 email-alert-api: GOVUK_APP_NAME=email-alert-api bundle exec rackup -p 3089
 imminence: GOVUK_APP_NAME=imminence bundle exec rackup -p 3120

--- a/public/index.html
+++ b/public/index.html
@@ -27,6 +27,7 @@
       <li><a href="/collections-publisher">Collections Publisher</a></li>
       <li><a href="/content-audit-tool">Content Audit Tool</a></li>
       <li><a href="/content-performance-manager">Content Performance Manager</a></li>
+      <li><a href="/content-publisher">Content Publisher</a></li>
       <li><a href="/content-tagger">Content Tagger</a></li>
       <li><a href="/email-alert-api">Email Alert API</a></li>
       <li><a href="/imminence">Imminence</a></li>


### PR DESCRIPTION
For https://trello.com/c/rXTLvzSu/685-scheduling-is-sent-to-the-publishing-api

Dependent on https://github.com/alphagov/govuk-puppet/pull/8778 before merging