### PR TITLE
Remove the link to Rummager

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -37,7 +37,6 @@
       <li><a href="/organisations-publisher">Organisations Publisher</a></li>
       <li><a href="/publisher">Publisher</a></li>
       <li><a href="/publishing-api">Publishing API</a></li>
-      <li><a href="/rummager">Rummager</a></li>
       <li><a href="/search-api">Search API</a></li>
       <li><a href="/signon">Signon</a></li>
       <li><a href="/specialist-publisher">Specialist Publisher</a></li>


### PR DESCRIPTION
As it's now been renamed to the Search API.