### PR TITLE
Remove content audit tool

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,6 +1,5 @@
 asset-manager: GOVUK_APP_NAME=asset-manager bundle exec rackup -p 3038
 collections-publisher: GOVUK_APP_NAME=collections-publisher bundle exec rackup -p 3216
-content-audit-tool: GOVUK_APP_NAME=content-audit-tool bundle exec rackup -p 3217
 content-data-admin: GOVUK_APP_NAME=content-data-admin bundle exec rackup -p 3240
 content-data-api: GOVUK_APP_NAME=content-data-api bundle exec rackup -p 3239
 content-publisher: GOVUK_APP_NAME=content-publisher bundle exec rackup -p 3236

--- a/public/index.html
+++ b/public/index.html
@@ -25,7 +25,6 @@
     <ul>
       <li><a href="/asset-manager">Asset Manager</a></li>
       <li><a href="/collections-publisher">Collections Publisher</a></li>
-      <li><a href="/content-audit-tool">Content Audit Tool</a></li>
       <li><a href="/content-data-admin">Content Data Admin</a></li>
       <li><a href="/content-data-api">Content Data API</a></li>
       <li><a href="/content-publisher">Content Publisher</a></li>


### PR DESCRIPTION
Content Audit Tool is a legacy application created before Content Data. It was used to help tag content - it shared a codebase with Content Performance Manager.

It is being retired as it should no longer be used, to clean up references to it in our codebase, and remove the need for developers to maintain it

[Trello](https://trello.com/c/V6bXwwtx/1700-3-retire-content-audit-app)