### PR TITLE
Use REDIS_URL instead of REDIS_HOST/REDIS_PORT

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -3,12 +3,11 @@ require 'sidekiq/web'
 app_name = ENV.fetch('GOVUK_APP_NAME')
 
 redis_prefix = app_name.tr('-', '_').upcase
-redis_host = ENV.fetch("#{redis_prefix}_REDIS_HOST", 'localhost')
-redis_port = ENV.fetch("#{redis_prefix}_REDIS_PORT", 6379)
+redis_url = ENV.fetch("#{redis_prefix}_REDIS_URL", 'redis://localhost:6379')
 redis_namespace = app_name
 
 Sidekiq.configure_client do |config|
-  config.redis = { host: redis_host, port: redis_port, namespace: redis_namespace }
+  config.redis = { url: redis_url, namespace: redis_namespace }
 end
 
 map "/#{app_name}" do


### PR DESCRIPTION
Trello: https://trello.com/c/dXud4WIt/206-inconsistent-redisurl-config

All GOV.UK projects are being migrated to use REDIS_URL to resolve the
mismatch where some have REDIS_HOST/REDIS_PORT and others have
REDIS_URL. This changes this project to use REDIS_URL. govuk-puppet
already sets a REDIS_URL env var for each project so this won't need a
corresponding puppet change.