### PR TITLE
Add healthcheck

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'foreman'
+gem 'govuk_app_config'
 gem 'rack'
 gem 'redis-namespace'
 gem 'sidekiq', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,47 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (6.1.3)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
     concurrent-ruby (1.0.5)
     connection_pool (2.2.1)
+    faraday (1.3.0)
+      faraday-net_http (~> 1.0)
+      multipart-post (>= 1.2, < 3)
+      ruby2_keywords
+    faraday-net_http (1.0.1)
     foreman (0.84.0)
       thor (~> 0.19.1)
+    govuk_app_config (2.8.4)
+      logstasher (>= 1.2.2, < 2.2.0)
+      sentry-raven (~> 3.1.1)
+      statsd-ruby (~> 1.5.0)
+      unicorn (>= 5.4, < 5.9)
+    i18n (1.8.9)
+      concurrent-ruby (~> 1.0)
+    kgio (2.11.3)
+    logstasher (2.1.5)
+      activesupport (>= 5.2)
+      request_store
+    minitest (5.14.4)
+    multipart-post (2.1.1)
     mustermann (1.0.3)
     rack (2.1.4)
     rack-protection (2.0.2)
       rack
+    raindrops (0.19.1)
     redis (4.0.1)
     redis-namespace (1.6.0)
       redis (>= 3.0.4)
+    request_store (1.5.0)
+      rack (>= 1.4)
+    ruby2_keywords (0.0.4)
+    sentry-raven (3.1.1)
+      faraday (>= 1.0)
     sidekiq (5.1.3)
       concurrent-ruby (~> 1.0)
       connection_pool (~> 2.2, >= 2.2.0)
@@ -22,14 +52,22 @@ GEM
       rack (~> 2.0)
       rack-protection (= 2.0.2)
       tilt (~> 2.0)
+    statsd-ruby (1.5.0)
     thor (0.19.4)
     tilt (2.0.10)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
+    unicorn (5.8.0)
+      kgio (~> 2.6)
+      raindrops (~> 0.7)
+    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   foreman
+  govuk_app_config
   rack
   redis-namespace
   sidekiq

--- a/Procfile
+++ b/Procfile
@@ -19,3 +19,5 @@ support-api: GOVUK_APP_NAME=support-api bundle exec rackup -p 3215
 transition: GOVUK_APP_NAME=transition bundle exec rackup -p 3086
 travel-advice-publisher: GOVUK_APP_NAME=travel-advice-publisher bundle exec rackup -p 3203
 whitehall: GOVUK_APP_NAME=whitehall bundle exec rackup -p 3081
+
+healthcheck: bundle exec rackup -p 3242

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,5 @@
 require 'sidekiq/web'
+require 'govuk_app_config'
 
 app_name = ENV.fetch('GOVUK_APP_NAME')
 
@@ -12,4 +13,8 @@ end
 
 map "/#{app_name}" do
   run Sidekiq::Web
+end
+
+map "/healthcheck" do
+  run GovukHealthcheck.rack_response(GovukHealthcheck::SidekiqRedis)
 end


### PR DESCRIPTION
As part of enabling continuous deployment we need to add a healthcheck to Sidekiq monitoring.

Related PR:
https://github.com/alphagov/govuk-puppet/pull/10972

Trello:
https://trello.com/c/C1cWKFAb/2392-5-enable-continuous-deployment-for-sidekiq-monitoring