### PR TITLE
Remove retired application from dashboard

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -8,7 +8,6 @@ email-alert-api: GOVUK_APP_NAME=email-alert-api bundle exec rackup -p 3089
 imminence: GOVUK_APP_NAME=imminence bundle exec rackup -p 3120
 link-checker-api: GOVUK_APP_NAME=link-checker-api bundle exec rackup -p 3209
 manuals-publisher: GOVUK_APP_NAME=manuals-publisher bundle exec rackup -p 3214
-organisations-publisher: GOVUK_APP_NAME=organisations-publisher bundle exec rackup -p 3219
 publisher: GOVUK_APP_NAME=publisher bundle exec rackup -p 3079
 publishing-api: GOVUK_APP_NAME=publishing-api bundle exec rackup -p 3114
 search-admin: GOVUK_APP_NAME=search-admin bundle exec rackup -p 3241

--- a/public/index.html
+++ b/public/index.html
@@ -33,7 +33,6 @@
       <li><a href="/imminence">Imminence</a></li>
       <li><a href="/link-checker-api">Link Checker API</a></li>
       <li><a href="/manuals-publisher">Manuals Publisher</a></li>
-      <li><a href="/organisations-publisher">Organisations Publisher</a></li>
       <li><a href="/publisher">Publisher</a></li>
       <li><a href="/publishing-api">Publishing API</a></li>
       <li><a href="/search-admin">Search Admin</a></li>


### PR DESCRIPTION
App has been [retired](https://github.com/alphagov/organisations-publisher).

Trello:
https://trello.com/c/C1cWKFAb/2392-5-enable-continuous-deployment-for-sidekiq-monitoring