### PR TITLE
Add RFC 141 healthcheck endpoints

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -18,3 +18,11 @@ end
 map "/healthcheck" do
   run GovukHealthcheck.rack_response(GovukHealthcheck::SidekiqRedis)
 end
+
+map "/healthcheck/live" do
+  run Proc.new { [200, {}, %w[OK]] }
+end
+
+map "/healthcheck/ready" do
+  run GovukHealthcheck.rack_response(GovukHealthcheck::SidekiqRedis)
+end


### PR DESCRIPTION
Once govuk-puppet has been updated, the old endpoint can be removed.

See the RFC for more details.

---

[Trello card](https://trello.com/c/tl6RV1el/723-improve-govuk-healthchecks)
