### PR TITLE
Remove legacy /healthcheck route

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -15,10 +15,6 @@ map "/#{app_name}" do
   run Sidekiq::Web
 end
 
-map "/healthcheck" do
-  run GovukHealthcheck.rack_response(GovukHealthcheck::SidekiqRedis)
-end
-
 map "/healthcheck/live" do
   run Proc.new { [200, {}, %w[OK]] }
 end


### PR DESCRIPTION
govuk-puppet and govuk-aws have now been updated to only use the new
routes, so the old one is no longer needed.

See RFC 141 for more information.

---

[Trello card](https://trello.com/c/tl6RV1el/723-improve-govuk-healthchecks)
