### PR TITLE
Add Licence reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,7 @@ $ ./bin/foreman start
 [Redis]: http://redis.io
 [Ruby]: https://www.ruby-lang.org
 [Sidekiq]: http://sidekiq.org
+
+## Licence
+
+[MIT License](LICENCE)


### PR DESCRIPTION
We want to make the reference to the licence in the README consistent with the GDS Way.

Trello card: https://trello.com/c/P0DpFcwW/260-standardise-all-license-files-names-to-licence