### PR TITLE
Pin version of govuk_sidekiq

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ gem 'foreman'
 gem 'govuk_app_config'
 gem 'rack'
 gem 'redis-namespace'
-gem 'govuk_sidekiq', require: false
+gem 'govuk_sidekiq', "< 6", require: false # Temp: pinned to avoid dependabot automatically upgrading as we'll need to do some work here to upgrade
 gem 'sinatra'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,11 +45,12 @@ GEM
       sentry-ruby (~> 5.3)
       statsd-ruby (~> 1.5)
       unicorn (~> 6.1)
-    govuk_sidekiq (6.0.0)
+    govuk_sidekiq (5.0.0)
       gds-api-adapters (>= 19.1.0)
       govuk_app_config (>= 1.1)
       redis-namespace (~> 1.6)
-      sidekiq (~> 6)
+      sidekiq (>= 5, < 6)
+      sidekiq-logging-json (~> 0.0)
       sidekiq-statsd (>= 2.1)
     http-accept (1.7.0)
     http-cookie (1.0.5)
@@ -122,10 +123,13 @@ GEM
       sentry-ruby (~> 5.7.0)
     sentry-ruby (5.7.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-    sidekiq (6.5.8)
-      connection_pool (>= 2.2.5, < 3)
+    sidekiq (5.2.10)
+      connection_pool (~> 2.2, >= 2.2.2)
       rack (~> 2.0)
-      redis (>= 4.5.0, < 5)
+      rack-protection (>= 1.5.0)
+      redis (~> 4.5, < 4.6.0)
+    sidekiq-logging-json (0.0.19)
+      sidekiq (>= 3)
     sidekiq-statsd (2.1.0)
       activesupport
       sidekiq (>= 3.3.1)
@@ -154,7 +158,7 @@ PLATFORMS
 DEPENDENCIES
   foreman
   govuk_app_config
-  govuk_sidekiq
+  govuk_sidekiq (< 6)
   rack
   redis-namespace
   sinatra


### PR DESCRIPTION
We will need to do more work to upgrade the version of sidekiq. Bumping the version without doing further work causes the application to 500 for all of the apps it monitors, so pinning to a previous version until we fix this fully.

[Ticket](https://trello.com/c/aVx282Rt/438-fix-sidekiq-monitoring-raising-500-errors-for-all-apps) for the proper fix

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
